### PR TITLE
Link bc files together to one bc if clang is used

### DIFF
--- a/Makefile.klee.in
+++ b/Makefile.klee.in
@@ -22,3 +22,8 @@ DOASSERTS = @ASSERTS@
 
 HOSTCC     = @HOSTCC@
 BUILD_CFLAGS = -O2 -Wall @EMIT_LLVM@
+
+ifeq ($(notdir @CC@), clang)
+ AR = $(TOOLDIR)@LINKER@
+ ARFLAGS = -o
+endif

--- a/Rules.mak
+++ b/Rules.mak
@@ -136,7 +136,7 @@ check_ld=$(shell \
 	if $(LD) $(1) -o /dev/null -b binary /dev/null > /dev/null 2>&1; \
 	then echo "$(1)"; fi)
 
-ARFLAGS:=cr
+ARFLAGS?=cr
 
 OPTIMIZATION:=
 # Use '-Os' optimization if available, else use -O2, allow Config to override


### PR DESCRIPTION
This is fix/workaround to use uClibc with KLEE & LLVM 3.3.

By linking all files into one .bc file we avoid relinking for every execution with KLEE.
This is a huge performance boost for ccadar/klee#70.
