### PR TITLE
features: support glibc 2.25

### DIFF
--- a/include/features.h
+++ b/include/features.h
@@ -155,6 +155,8 @@
 # define __GNUC_PREREQ(maj, min) 0
 #endif
 
+/* Whether to use feature set F.  */
+#define __GLIBC_USE(F) __GLIBC_USE_ ## F
 
 /* If _BSD_SOURCE was defined by the user, favor BSD over POSIX.  */
 #if defined _BSD_SOURCE && \


### PR DESCRIPTION
With glibc 2.25, we see:
```
In file included from libc/misc/assert/__assert.c:33:
In file included from ./include/bits/uClibc_uintmaxtostr.h:42:
In file included from ./include/limits.h:124:
/usr/include/limits.h:147:17: error: token is not a valid binary operator in a preprocessor subexpression
    ~~~~~~~~~~~ ^
```
Fix that by defining __GLIBC_USE macro in our features.h
