### PR TITLE
Add Travis-CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,78 @@
+sudo: required
+dist: trusty
+language: cpp
+compiler:
+    # FIXME: For now, building with Clang is disabled because the STP built with
+    # it hits an assertion failure during some tests. We should sort this out
+    # eventually and file the bug against STP or Clang whichever is appropriate,
+    # but for now it is easier to just reduce the number of configs we test
+    # anyway.
+    # - clang
+
+    - gcc
+env:
+    ###########################################################################
+    # Configurations
+    #
+    # Each line in the "env" section represents a set of environment variables
+    # passed to a build. Thus each line represents a different build
+    # configuration.
+    ###########################################################################
+
+    # Check a subset of the matrix of:
+    #   LLVM  : {2.9, 3.4}
+    #   SOLVERS : {Z3}
+    #   DISABLE_ASSERTIONS: {0}
+    #   ENABLE_OPTIMIZED: {1}
+    #   USE_CMAKE: {0, 1}
+
+    # Check KLEE CMake build in a few configurations
+    - LLVM_VERSION=3.4 SOLVERS=Z3 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 USE_CMAKE=1
+    - LLVM_VERSION=2.9 SOLVERS=Z3 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 USE_CMAKE=1
+
+    # Check KLEE Autoconf build in a few configurations
+    - LLVM_VERSION=3.4 SOLVERS=Z3 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 USE_CMAKE=0
+    - LLVM_VERSION=2.9 SOLVERS=Z3 DISABLE_ASSERTIONS=0 ENABLE_OPTIMIZED=1 USE_CMAKE=0
+
+addons:
+  apt:
+    sources:
+    - sourceline: 'ppa:ubuntu-toolchain-r/test'
+    - sourceline: 'ppa:h-rayflood/llvm'
+    - sourceline: 'deb http://download.opensuse.org/repositories/home:/delcypher:/z3/xUbuntu_14.04/ /'
+      key_url: 'http://download.opensuse.org/repositories/home:delcypher:z3/xUbuntu_14.04/Release.key'
+    packages:
+    - gcc-4.8
+    - g++-4.8
+    - libcap-dev
+    - libselinux1-dev
+    - cmake
+
+cache: apt
+before_install:
+    ###########################################################################
+    # Set up the locations to get various packages from
+    # We assume the Travis image uses Ubuntu 14.04 LTS
+    ###########################################################################
+    # Update package information
+    - sudo apt-get update
+    ###########################################################################
+    # Set up out of source build directory
+    ###########################################################################
+    - export SRC_DIR=`pwd`
+    - cd ../
+    - mkdir build
+    - cd build/
+    - export BUILD_DIR=`pwd`
+    ###########################################################################
+    # Install stuff
+    ###########################################################################
+    # Install LLVM and the LLVM bitcode compiler we require to build KLEE
+    - ${SRC_DIR}/.travis/install-llvm-and-runtime-compiler.sh
+    # Install lit (llvm-lit is not available)
+    - sudo pip install lit
+script:
+    # Build uclibc
+    - ${SRC_DIR}/.travis/uclibc.sh
+    # Test uclibc integration with KLEE
+    - ${SRC_DIR}/.travis/klee.sh

--- a/.travis/install-llvm-and-runtime-compiler.sh
+++ b/.travis/install-llvm-and-runtime-compiler.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -x
+set -ev
+
+sudo apt-get install -y llvm-${LLVM_VERSION} llvm-${LLVM_VERSION}-dev
+
+if [ "${LLVM_VERSION}" != "2.9" ]; then
+    sudo apt-get install -y llvm-${LLVM_VERSION}-tools clang-${LLVM_VERSION}
+    sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} 20
+    sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 20
+else
+    # Get llvm-gcc. We don't bother installing it
+    wget http://llvm.org/releases/2.9/llvm-gcc4.2-2.9-x86_64-linux.tar.bz2
+    tar -xjf llvm-gcc4.2-2.9-x86_64-linux.tar.bz2
+    mv llvm-gcc4.2-2.9-x86_64-linux llvm-gcc
+
+    # Hack to make llvm-gcc capable of building a native executable
+    OLD_DIR=$(pwd)
+    cd llvm-gcc/lib/gcc/x86_64-unknown-linux-gnu/4.2.1
+    ln -s /usr/lib/x86_64-linux-gnu/crt1.o
+    ln -s /usr/lib/x86_64-linux-gnu/crti.o
+    ln -s /usr/lib/x86_64-linux-gnu/crtn.o
+    cd "$OLD_DIR"
+
+    # Check it can compile hello world
+    echo -e "#include <stdio.h> \n int main(int argc, char** argv) { printf(\"Hello World\"); return 0;}" > test.c
+    export C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu
+    export CPLUS_INCLUDE_PATH=/usr/include/x86_64-linux-gnu
+    llvm-gcc/bin/llvm-gcc test.c -o hello_world
+    ./hello_world
+fi

--- a/.travis/klee.sh
+++ b/.travis/klee.sh
@@ -1,0 +1,147 @@
+#!/bin/bash -x
+# Make sure we exit if there is a failure
+set -e
+: ${SOLVERS?"Solvers must be specified"}
+
+source ${SRC_DIR}/.travis/llvm_compiler.sh
+
+###############################################################################
+# Clone KLEE source code
+###############################################################################
+git clone https://github.com/klee/klee.git ${SRC_DIR}/klee
+
+###############################################################################
+# Testing utils for KLEE
+###############################################################################
+source ${SRC_DIR}/.travis/testing-utils.sh
+
+cd ${BUILD_DIR}
+
+###############################################################################
+# Setting up solvers for KLEE
+###############################################################################
+source ${SRC_DIR}/.travis/solvers.sh
+
+KLEE_Z3_CONFIGURE_OPTION=""
+SOLVER_LIST=$(echo "${SOLVERS}" | sed 's/:/ /')
+
+if [ "X${USE_CMAKE}" == "X1" ]; then
+  # Set CMake configure options
+  for solver in ${SOLVER_LIST}; do
+    echo "Setting CMake configuration option for ${solver}"
+    case ${solver} in
+    Z3)
+      echo "Z3"
+      KLEE_Z3_CONFIGURE_OPTION="-DENABLE_SOLVER_Z3=TRUE"
+      ;;
+    *)
+      echo "Unknown solver ${solver}"
+      exit 1
+    esac
+  done
+else
+  for solver in ${SOLVER_LIST}; do
+    echo "Setting configuration option for ${solver}"
+    case ${solver} in
+    Z3)
+      echo "Z3"
+      KLEE_Z3_CONFIGURE_OPTION="--with-z3=/usr"
+      ;;
+    *)
+      echo "Unknown solver ${solver}"
+      exit 1
+    esac
+  done
+fi
+
+###############################################################################
+# Compile KLEE and run tests
+###############################################################################
+mkdir klee-build
+cd klee-build
+
+if [ "X${USE_CMAKE}" == "X1" ]; then
+  KLEE_UCLIBC_CONFIGURE_OPTION="-DENABLE_KLEE_UCLIBC=TRUE -DKLEE_UCLIBC_PATH=${SRC_DIR} -DENABLE_POSIX_RUNTIME=TRUE"
+else
+  KLEE_UCLIBC_CONFIGURE_OPTION="--with-uclibc=${SRC_DIR} --enable-posix-runtime"
+fi
+
+if [ "X${USE_CMAKE}" == "X1" ]; then
+  GTEST_SRC_DIR="${BUILD_DIR}/test-utils/googletest-release-1.7.0/"
+  if [ "X${DISABLE_ASSERTIONS}" == "X1" ]; then
+    KLEE_ASSERTS_OPTION="-DENABLE_KLEE_ASSERTS=FALSE"
+  else
+    KLEE_ASSERTS_OPTION="-DENABLE_KLEE_ASSERTS=TRUE"
+  fi
+
+  if [ "X${ENABLE_OPTIMIZED}" == "X1" ]; then
+    CMAKE_BUILD_TYPE="RelWithDebInfo"
+  else
+    CMAKE_BUILD_TYPE="Debug"
+  fi
+
+  # Compute CMake build type
+  cmake \
+    -DLLVM_CONFIG_BINARY="/usr/lib/llvm-${LLVM_VERSION}/bin/llvm-config" \
+    -DLLVMCC="${KLEE_CC}" \
+    -DLLVMCXX="${KLEE_CXX}" \
+    ${KLEE_Z3_CONFIGURE_OPTION} \
+    ${KLEE_UCLIBC_CONFIGURE_OPTION} \
+    -DGTEST_SRC_DIR=${GTEST_SRC_DIR} \
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+    ${KLEE_ASSERTS_OPTION} \
+    -DENABLE_UNIT_TESTS=TRUE \
+    -DENABLE_SYSTEM_TESTS=TRUE \
+    -DLIT_ARGS="-v" \
+    ${SRC_DIR}/klee
+  make
+else
+  # Build KLEE
+  # Note: ENABLE_SHARED=0 is required because llvm-2.9 is incorectly packaged
+  # and is missing the shared library that was supposed to be built that the build
+  # system will try to use by default.
+  ${SRC_DIR}/klee/configure --with-llvmsrc=/usr/lib/llvm-${LLVM_VERSION}/build \
+              --with-llvmobj=/usr/lib/llvm-${LLVM_VERSION}/build \
+              --with-llvmcc=${KLEE_CC} \
+              --with-llvmcxx=${KLEE_CXX} \
+              ${KLEE_Z3_CONFIGURE_OPTION} \
+              ${KLEE_UCLIBC_CONFIGURE_OPTION}
+  make  DISABLE_ASSERTIONS=${DISABLE_ASSERTIONS} \
+        ENABLE_OPTIMIZED=${ENABLE_OPTIMIZED} \
+        ENABLE_SHARED=0
+fi
+
+###############################################################################
+# Unit tests
+###############################################################################
+if [ "X${USE_CMAKE}" == "X1" ]; then
+  make unittests
+else
+  # The unittests makefile doesn't seem to have been packaged so get it from SVN
+  sudo mkdir -p /usr/lib/llvm-${LLVM_VERSION}/build/unittests/
+  svn export  http://llvm.org/svn/llvm-project/llvm/branches/${SVN_BRANCH}/unittests/Makefile.unittest \
+      ../Makefile.unittest
+  sudo mv ../Makefile.unittest /usr/lib/llvm-${LLVM_VERSION}/build/unittests/
+
+  make unittests \
+      DISABLE_ASSERTIONS=${DISABLE_ASSERTIONS} \
+      ENABLE_OPTIMIZED=${ENABLE_OPTIMIZED} \
+      ENABLE_SHARED=0
+fi
+
+###############################################################################
+# lit tests
+###############################################################################
+if [ "X${USE_CMAKE}" == "X1" ]; then
+  make systemtests
+else
+  # Note can't use ``make check`` because llvm-lit is not available
+  cd test
+  # The build system needs to generate this file before we can run lit
+  make lit.site.cfg \
+      DISABLE_ASSERTIONS=${DISABLE_ASSERTIONS} \
+      ENABLE_OPTIMIZED=${ENABLE_OPTIMIZED} \
+      ENABLE_SHARED=0
+  cd ../
+  lit -v test/
+fi

--- a/.travis/llvm_compiler.sh
+++ b/.travis/llvm_compiler.sh
@@ -1,0 +1,25 @@
+# This file is meant to be included by shell scripts
+# to compute the correct version of the LLVM compiler to use.
+
+# Calculate LLVM branch name to retrieve missing files from
+SVN_BRANCH="release_$( echo ${LLVM_VERSION} | sed 's/\.//g')"
+
+###############################################################################
+# Select the compiler to use to generate LLVM bitcode
+###############################################################################
+if [ "${LLVM_VERSION}" != "2.9" ]; then
+    KLEE_CC=/usr/bin/clang-${LLVM_VERSION}
+    KLEE_CXX=/usr/bin/clang++-${LLVM_VERSION}
+else
+    # Just use pre-built llvm-gcc downloaded earlier
+    KLEE_CC=${BUILD_DIR}/llvm-gcc/bin/llvm-gcc
+    KLEE_CXX=${BUILD_DIR}/llvm-gcc/bin/llvm-g++
+    export C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu
+    export CPLUS_INCLUDE_PATH=/usr/include/x86_64-linux-gnu
+
+    # Add symlinks to fix llvm-2.9-dev package so KLEE can configure properly
+    # Because of the way KLEE's configure script works this must be a relative
+    # symlink, **not** absolute!
+    test -L '/usr/lib/llvm-2.9/build/Release' || sudo sh -c 'cd /usr/lib/llvm-2.9/build/ && ln -s ../ Release'
+    test -L '/usr/lib/llvm-2.9/build/include' || sudo sh -c 'cd /usr/lib/llvm-2.9/build/ && ln -s ../include include'
+fi

--- a/.travis/solvers.sh
+++ b/.travis/solvers.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -x
+# Make sure we exit if there is a failure
+set -e
+: ${SOLVERS?"Solvers must be specified"}
+
+SOLVER_LIST=$(echo "${SOLVERS}" | sed 's/:/ /')
+
+for solver in ${SOLVER_LIST}; do
+  echo "Getting solver ${solver}"
+  case ${solver} in
+  Z3)
+    echo "Z3"
+    # Should we install libz3-dbg too?
+    sudo apt-get -y install libz3 libz3-dev
+    ;;
+  *)
+    echo "Unknown solver ${solver}"
+    exit 1
+  esac
+done

--- a/.travis/testing-utils.sh
+++ b/.travis/testing-utils.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -x
+# Make sure we exit if there is a failure
+set -e
+
+mkdir ${BUILD_DIR}/test-utils/
+cd ${BUILD_DIR}/test-utils/
+
+if [ "X${USE_CMAKE}" == "X1" ]; then
+    # The New CMake build system just needs the GTest sources regardless
+    # of LLVM version.
+    wget https://github.com/google/googletest/archive/release-1.7.0.zip
+    unzip release-1.7.0.zip
+else
+  if [ "${LLVM_VERSION}" != "2.9" ]; then
+      # Using LLVM3.4 all we need is vanilla GoogleTest :)
+      wget https://github.com/google/googletest/archive/release-1.7.0.zip
+      unzip release-1.7.0.zip
+      cd googletest-release-1.7.0/
+      cmake .
+      make
+      # Normally I wouldn't do something like this but hey we're running on a temporary virtual machine, so who cares?
+      sudo cp lib* /usr/lib/
+      sudo cp -r include/gtest /usr/include
+  else
+      # LLVM2.9 on the other hand is a pain
+
+      # We need the version of GoogleTest used in LLVM2.9
+      # This is a hack
+      old=`pwd`
+      cd ${SRC_DIR}/klee/tools/
+      svn export http://llvm.org/svn/llvm-project/llvm/branches/release_29/utils/unittest unittest
+
+      # Now put the header files in the search path so building will succeed
+      sudo cp -r unittest/googletest/include/gtest /usr/include/
+
+      # We need the FileCheck and not utilites as well because they aren't in the llvm-2.9-dev package
+      for tool in FileCheck not; do
+          svn export http://llvm.org/svn/llvm-project/llvm/branches/release_29/utils/${tool} ${tool}
+          # Patch the Makefile so it will work in KLEE's build system
+          sed -i 's/^USEDLIBS.*$/LINK_COMPONENTS = support/' ${tool}/Makefile
+      done
+
+      # Now hack the make file to build the unittest library and the FileCheck and not tools
+      sed -i '0,/^PARALLEL_DIRS/a PARALLEL_DIRS += unittest FileCheck not' Makefile
+
+      cd "${old}"
+  fi
+fi

--- a/.travis/uclibc.sh
+++ b/.travis/uclibc.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+# Make sure we exit if there is a failure
+set -e
+
+source ${SRC_DIR}/.travis/llvm_compiler.sh
+
+cd ${SRC_DIR}
+./configure --make-llvm-lib --with-cc "${KLEE_CC}" --with-llvm-config /usr/bin/llvm-config-${LLVM_VERSION}
+make


### PR DESCRIPTION
Added Travis-CI integration. The script is heavily based on the one used in KLEE.
The build script compiles and runs KLEE with the current build version of uclibc.