### PR TITLE
Fix compilation when __STDIO_HAS_OPENLIST is undefined

### DIFF
--- a/libc/stdio/_scanf.c
+++ b/libc/stdio/_scanf.c
@@ -318,7 +318,9 @@ int vsscanf(__const char *sp, __const char *fmt, va_list ap)
 	f.f.__user_locking = 1;		/* Set user locking. */
 	__stdio_init_mutex(&f.f.__lock);
 #endif
+#ifdef __STDIO_HAS_OPENLIST
 	f.f.__nextopen = NULL;
+#endif
 
 	return vfscanf(&f.f, fmt, ap);
 }

--- a/libc/stdio/vdprintf.c
+++ b/libc/stdio/vdprintf.c
@@ -52,7 +52,9 @@ int vdprintf(int filedes, const char * __restrict format, va_list arg)
 	f.__user_locking = 1;		/* Set user locking. */
 	__stdio_init_mutex(&f.__lock);
 #endif
+#ifdef __STDIO_HAS_OPENLIST
 	f.__nextopen = NULL;
+#endif
 
 	rv = vfprintf(&f, format, arg);
 


### PR DESCRIPTION
`__STDIO_HAS_OPENLIST` is undefined if none of `__STDIO_BUFFERS`,  `__UCLIBC_HAS_GLIBC_CUSTOM_STREAMS__` and `__UCLIBC_HAS_THREADS__` are defined, but there is code that uses `__nextopen` even if all four of those are undefined.

This is a quick fix, I'm not knowledgeable abouc uclibc internals so maybe there's a better way to do this (e.g. ifdef out larger chunks of code?).