### PR TITLE
Fix inconsistent implementations of realpath in klee-uclibc

### DIFF
--- a/libc/string/strdup.c
+++ b/libc/string/strdup.c
@@ -20,6 +20,17 @@ libc_hidden_proto(strlen)
 #endif
 libc_hidden_proto(memcpy)
 
+char *__strdup(const char* s1) {
+	register char *s;
+	register size_t l = (strlen(s1) + 1) * sizeof(char);
+
+	if ((s = malloc(l)) != NULL) {
+		memcpy(s, s1, l);
+	}
+
+	return s;
+}
+
 Wchar *Wstrdup(register const Wchar *s1)
 {
 	register Wchar *s;


### PR DESCRIPTION
Hi There

I found there exist some incomplete or unsupported functions in klee-uclibc during my testing with KLEE, I created a simple patch based on current klee-uclibc repo, please check. 

1. Inconsistent implementation with realpath of uclibc
when I tested programs containing realpath functions, KLEE failed to interpret it correctly, then I found it is caused by obsolete realpath function, so I incorporated the current implementation of realpath in uclibc into klee-uclibc. It works well now.

2. libc/string/strdup.c does not include __strdup implementation
When I tested binutils, I found that strdup call will be compiled to __strdup which is interpreted incorrectly by KLEE, so I added the implementation based on Wstrdup.

Thanks
Peng