### PR TITLE
Add fast-path for memset, memcpy, and memmove

### DIFF
--- a/libc/string/memcpy.c
+++ b/libc/string/memcpy.c
@@ -15,8 +15,14 @@
 
 libc_hidden_proto(Wmemcpy)
 
+char __klee_handle_memcpy(void *, const void *, size_t);
+
 Wvoid *Wmemcpy(Wvoid * __restrict s1, const Wvoid * __restrict s2, size_t n)
 {
+
+	if (__klee_handle_memcpy(s1, s2, n))
+		return s1;
+
 	register Wchar *r1 = s1;
 	register const Wchar *r2 = s2;
 

--- a/libc/string/memmove.c
+++ b/libc/string/memmove.c
@@ -14,8 +14,13 @@ libc_hidden_proto(memmove)
 # define Wmemmove memmove
 #endif
 
+char __klee_handle_memmove(void *, const void *, size_t);
+
 Wvoid *Wmemmove(Wvoid *s1, const Wvoid *s2, size_t n)
 {
+	if(__klee_handle_memmove(s1, s2, n))
+		return s1;
+
 #ifdef __BCC__
 	register Wchar *s = (Wchar *) s1;
 	register const Wchar *p = (const Wchar *) s2;

--- a/libc/string/memset.c
+++ b/libc/string/memset.c
@@ -14,8 +14,13 @@ libc_hidden_proto(memset)
 # define Wmemset memset
 #endif
 
+char __klee_handle_memset(void *, int, size_t);
+
 Wvoid *Wmemset(Wvoid *s, Wint c, size_t n)
 {
+	if (__klee_handle_memset(s, c, n))
+		return s;
+
 	register Wuchar *p = (Wuchar *) s;
 #ifdef __BCC__
 	/* bcc can optimize the counter if it thinks it is a pointer... */


### PR DESCRIPTION
The additional "calls" to `__klee_handle_mem{set|cpy|move}` are intercepted by the klee
`SpecialFunctionHandler` and implement the intended functionality directly in
concrete cases. The associated PR in klee is at https://github.com/klee/klee/pull/1341 which needs to go in before this gets merged.