### PR TITLE
Opt out of inline assembly in libc/sysdeps/linux/*/bits/select.h

### DIFF
--- a/libc/sysdeps/linux/i386/bits/select.h
+++ b/libc/sysdeps/linux/i386/bits/select.h
@@ -21,7 +21,7 @@
 #endif
 
 
-#if defined __GNUC__ && __GNUC__ >= 2
+#if 0 && defined __GNUC__ && __GNUC__ >= 2
 
 # define __FD_ZERO(fdsp) \
   do {									      \

--- a/libc/sysdeps/linux/microblaze/bits/select.h
+++ b/libc/sysdeps/linux/microblaze/bits/select.h
@@ -15,7 +15,8 @@
 # error "Never use <bits/select.h> directly; include <sys/select.h> instead."
 #endif
 
-#ifdef __GNUC__
+#if 0
+//#ifdef __GNUC__
 
 /* We don't use `memset' because this would require a prototype and
    the array isn't too big.  */

--- a/libc/sysdeps/linux/v850/bits/select.h
+++ b/libc/sysdeps/linux/v850/bits/select.h
@@ -14,7 +14,8 @@
 # error "Never use <bits/select.h> directly; include <sys/select.h> instead."
 #endif
 
-#ifdef __GNUC__
+#if 0
+//#ifdef __GNUC__
 
 /* We don't use `memset' because this would require a prototype and
    the array isn't too big.  */


### PR DESCRIPTION
`FD_ZERO` and `FD_SET` use inline assembly that is not supported by KLEE. With this patch, we force the fallback path to C code.