### PR TITLE
configure: use Python 3 explicitly

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Configure the build of klee-uclibc. It can be built
 as a native library or as an LLVM bitcode archive.


### PR DESCRIPTION
Some Linux distributions, e.g. Fedora, do not install the unversioned Python binary by default and Python 2 has been dead for more than a year.