### PR TITLE
extra/locale/Makefile: don't always require curl/wget

### DIFF
--- a/extra/locale/Makefile.in
+++ b/extra/locale/Makefile.in
@@ -6,6 +6,7 @@
 #
 
 # command used to download source code
+ifeq ($(UCLIBC_DOWNLOAD_PREGENERATED_LOCALE_DATA),y)
 GET  :=
 WGET := $(shell command -v wget 2> /dev/null)
 CURL := $(shell command -v curl 2> /dev/null)
@@ -17,6 +18,7 @@ ifneq (, $(CURL))
 GET += $(CURL) -OL
 else
 $(error "curl/wget not found")
+endif
 endif
 endif
 


### PR DESCRIPTION
Especially when `UCLIBC_DOWNLOAD_PREGENERATED_LOCALE_DATA` is unset.