### PR TITLE
fix Clang-15: make int-conversion a warning

### DIFF
--- a/Makefile.klee.in
+++ b/Makefile.klee.in
@@ -8,7 +8,7 @@
 
 TOOLDIR = @TOOLDIR@
 
-CC         = @CC@ @EMIT_LLVM@ $(KLEE_CFLAGS)
+CC         = @CC@ -Wno-error=int-conversion @EMIT_LLVM@ $(KLEE_CFLAGS)
 AR         = $(TOOLDIR)@ARCHIVER@
 LD         = $(TOOLDIR)@LINKER@
 NM         = $(TOOLDIR)@NM@


### PR DESCRIPTION
Currently the build with Clang 15 is broken as `int-conversion`s are treated as errors now. Add `-Wno-error=int-conversion` to compilation flags as a workaround.